### PR TITLE
LHJ-75: Add provider select component

### DIFF
--- a/languages/fame_lahjoitukset.pot
+++ b/languages/fame_lahjoitukset.pot
@@ -217,7 +217,7 @@ msgid "Invalid last name"
 msgstr ""
 
 #: build/Blocks/donation-form/view.js:532
-msgid "Email name is required"
+msgid "Email is required"
 msgstr ""
 
 #: build/Blocks/donation-form/view.js:533

--- a/src/Blocks/common/Providers.ts
+++ b/src/Blocks/common/Providers.ts
@@ -21,7 +21,7 @@ export const PROVIDERS: Provider[] = [
 	{
 		value: 'checkout',
 		label: __('Paytrail', 'fame_lahjoitukset'),
-		types: ['single'],
+		types: ['single', 'recurring'],
 	},
 	{
 		value: 'finvoice',
@@ -31,6 +31,6 @@ export const PROVIDERS: Provider[] = [
 	{
 		value: 'paymenthighway',
 		label: __('Payment Highway', 'fame_lahjoitukset'),
-		types: [],
+		types: ['single'],
 	},
 ]

--- a/src/Blocks/common/Providers.ts
+++ b/src/Blocks/common/Providers.ts
@@ -23,14 +23,4 @@ export const PROVIDERS: Provider[] = [
 		label: __('Paytrail', 'fame_lahjoitukset'),
 		types: ['single', 'recurring'],
 	},
-	{
-		value: 'finvoice',
-		label: __('Finvoice', 'fame_lahjoitukset'),
-		types: [],
-	},
-	{
-		value: 'paymenthighway',
-		label: __('Payment Highway', 'fame_lahjoitukset'),
-		types: ['single'],
-	},
 ]

--- a/src/Blocks/donation-amounts/block.json
+++ b/src/Blocks/donation-amounts/block.json
@@ -60,7 +60,7 @@
 			"type": "string",
 			"source": "text",
 			"selector": ".fame-form__legend",
-			"default": "Donation type"
+			"default": "Donation amount"
 		},
 		"other": {
 			"type": "boolean",

--- a/src/Blocks/donation-form/edit.tsx
+++ b/src/Blocks/donation-form/edit.tsx
@@ -8,8 +8,9 @@ import { EditProps } from '../common/types.ts'
 
 const TEMPLATE_LOCK = { lock: { remove: 'true' } }
 const TEMPLATE = [
-	'famehelsinki/donation-amounts',
 	'famehelsinki/donation-type',
+	'famehelsinki/donation-amounts',
+	'famehelsinki/donation-providers',
 	'famehelsinki/form-controls',
 ].map(block => [block, TEMPLATE_LOCK, []] as const)
 

--- a/src/Blocks/donation-form/save.tsx
+++ b/src/Blocks/donation-form/save.tsx
@@ -28,8 +28,7 @@ export default function save({ attributes }: SaveProps): React.JSX.Element {
 
 				<input type="hidden" name="return_address" value={returnAddress || '/'} />
 
-				{/** @todo implement configurable providers */}
-				<input type="hidden" name="provider" value="mobilepay" />
+				<input type="hidden" name="provider" data-selected-provider />
 
 				{campaign && <input type="hidden" name="campaign" value={campaign} />}
 			</form>

--- a/src/Blocks/donation-form/view.ts
+++ b/src/Blocks/donation-form/view.ts
@@ -13,23 +13,6 @@ domReady(() => {
 	const form = document.querySelector<HTMLFormElement>('form.fame-form--donations')
 	if (!form) return
 
-	const providerField = form.querySelector<HTMLInputElement>(
-		'input[name="provider"][data-selected-provider]'
-	)
-	const providerRadios = document.querySelectorAll<HTMLInputElement>(
-		'input[type="radio"][name^="provider"]'
-	)
-
-	const updateProvider = () => {
-		const selected = Array.from(providerRadios).find(r => r.checked)
-		if (selected && providerField) {
-			providerField.value = selected.value
-		}
-	}
-
-	updateProvider()
-	providerRadios.forEach(radio => radio.addEventListener('change', updateProvider))
-
 	const translations = {
 		amount: {
 			unknown: __('Invalid amount', 'fame_lahjoitukset'),
@@ -43,7 +26,7 @@ domReady(() => {
 			unknown: __('Invalid last name', 'fame_lahjoitukset'),
 		},
 		email: {
-			required: __('Email name is required', 'fame_lahjoitukset'),
+			required: __('Email is required', 'fame_lahjoitukset'),
 			unknown: __('Invalid email', 'fame_lahjoitukset'),
 		},
 		phone: {

--- a/src/Blocks/donation-form/view.ts
+++ b/src/Blocks/donation-form/view.ts
@@ -10,6 +10,26 @@ domReady(() => {
 		throw new Error('Backend URL is missing')
 	}
 
+	const form = document.querySelector<HTMLFormElement>('form.fame-form--donations')
+	if (!form) return
+
+	const providerField = form.querySelector<HTMLInputElement>(
+		'input[name="provider"][data-selected-provider]'
+	)
+	const providerRadios = document.querySelectorAll<HTMLInputElement>(
+		'input[type="radio"][name^="provider"]'
+	)
+
+	const updateProvider = () => {
+		const selected = Array.from(providerRadios).find(r => r.checked)
+		if (selected && providerField) {
+			providerField.value = selected.value
+		}
+	}
+
+	updateProvider()
+	providerRadios.forEach(radio => radio.addEventListener('change', updateProvider))
+
 	const translations = {
 		amount: {
 			unknown: __('Invalid amount', 'fame_lahjoitukset'),
@@ -31,10 +51,5 @@ domReady(() => {
 		},
 	}
 
-	document
-		.querySelectorAll('form.fame-form--donations')
-		.forEach(
-			form =>
-				form instanceof HTMLFormElement && new FormHandler(backendUrl, form, translations)
-		)
+	new FormHandler(backendUrl, form, translations)
 })

--- a/src/Blocks/donation-providers/ProviderHandler.ts
+++ b/src/Blocks/donation-providers/ProviderHandler.ts
@@ -1,0 +1,81 @@
+/**
+ * Donation/Payment provider handler.
+ */
+export default class ProviderHandler {
+	#typeInputs: NodeListOf<HTMLInputElement>
+	#providerSections: NodeListOf<HTMLElement>
+	#providerRadios: NodeListOf<HTMLInputElement>
+	#providerHiddens: NodeListOf<HTMLInputElement>
+	#selectedProviderField?: HTMLInputElement
+	#form?: HTMLFormElement
+
+	constructor() {
+		this.#typeInputs = document.querySelectorAll('input[name="type"]')
+		this.#providerSections = document.querySelectorAll(
+			'fieldset.payment-method-selector[data-type]'
+		)
+		this.#providerRadios = document.querySelectorAll('input[type="radio"][name="provider"]')
+		this.#providerHiddens = document.querySelectorAll(
+			'input[type="hidden"][name="provider"][data-type]'
+		)
+		this.#selectedProviderField = document.querySelector(
+			'input[name="provider"][data-selected-provider]'
+		)
+		this.#form = document.querySelector('form.fame-form--donations')
+
+		this.#bindEvents()
+		this.#updateUI()
+	}
+
+	#bindEvents() {
+		this.#typeInputs.forEach(i => i.addEventListener('change', this.#updateUI.bind(this)))
+		this.#providerRadios.forEach(r => r.addEventListener('change', this.#updateUI.bind(this)))
+		this.#form?.addEventListener('submit', () => {
+			this.#updateUI()
+		})
+	}
+
+	/**
+	 * Updates the UI based on the selected provider type and provider.
+	 */
+	#updateUI() {
+		const selectedType = Array.from(this.#typeInputs).find(i => i.checked)?.value
+
+		if (!selectedType) return
+
+		this.#providerSections.forEach(section => {
+			const radios = section.querySelectorAll<HTMLInputElement>('input[type="radio"]')
+			const isSingle = radios.length === 1
+
+			if (isSingle) {
+				section.style.display = 'none'
+			} else if (section.dataset.type === selectedType) {
+				section.style.display = 'block'
+			} else {
+				section.style.display = 'none'
+			}
+		})
+
+		this.#providerHiddens.forEach(h => {
+			h.disabled = h.dataset.type !== selectedType
+		})
+
+		if (this.#selectedProviderField) {
+			const activeRadio = Array.from(this.#providerRadios).find(
+				r =>
+					r.closest(`fieldset[data-type="${selectedType}"]`) &&
+					getComputedStyle(r.closest('fieldset')!).display !== 'none' &&
+					r.checked
+			)
+
+			if (activeRadio) {
+				this.#selectedProviderField.value = activeRadio.value
+			} else {
+				const activeHidden = Array.from(this.#providerHiddens).find(
+					h => h.dataset.type === selectedType && !h.disabled
+				)
+				this.#selectedProviderField.value = activeHidden ? activeHidden.value : ''
+			}
+		}
+	}
+}

--- a/src/Blocks/donation-providers/ProviderHandler.ts
+++ b/src/Blocks/donation-providers/ProviderHandler.ts
@@ -39,9 +39,16 @@ export default class ProviderHandler {
 	 * Updates the UI based on the selected provider type and provider.
 	 */
 	#updateUI() {
-		const selectedType = Array.from(this.#typeInputs).find(i => i.checked)?.value
+		const typeInputs = Array.from(this.#typeInputs)
+		let selectedType = typeInputs.find(i => i.checked)?.value
 
-		if (!selectedType) return
+		if (!selectedType && typeInputs.length === 1) {
+			selectedType = typeInputs[0].value
+		}
+
+		if (!selectedType) {
+			return
+		}
 
 		this.#providerSections.forEach(section => {
 			const radios = section.querySelectorAll<HTMLInputElement>('input[type="radio"]')

--- a/src/Blocks/donation-providers/block.json
+++ b/src/Blocks/donation-providers/block.json
@@ -1,0 +1,58 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "famehelsinki/donation-providers",
+	"version": "0.1.0",
+	"title": "Donation providers",
+	"category": "widgets",
+	"description": "Allows selecting donation providers.",
+	"parent": ["famehelsinki/donation-form"],
+	"usesContext": ["famehelsinki/donation-types"],
+	"attributes": {
+		"showLegend": {
+			"type": "boolean",
+			"default": true
+		},
+		"legend": {
+			"type": "string",
+			"source": "text",
+			"selector": "legend.fame-form__legend",
+			"default": "Provider type"
+		},
+		"providers": {
+			"type": "array",
+			"source": "query",
+			"selector": ".payment-method-selector > div",
+			"query": {
+				"value": {
+					"type": "string",
+					"source": "attribute",
+					"selector": "input",
+					"attribute": "value"
+				},
+				"label": {
+					"type": "string",
+					"source": "text",
+					"selector": ".provider-type__label"
+				}
+			},
+			"default": []
+		}
+	},
+	"supports": {
+		"multiple": false,
+		"color": {
+			"background": false,
+			"text": true
+		},
+		"html": false,
+		"typography": {
+			"fontSize": true
+		}
+	},
+	"icon": "edit-page",
+	"textdomain": "fame_lahjoitukset",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css"
+}

--- a/src/Blocks/donation-providers/block.json
+++ b/src/Blocks/donation-providers/block.json
@@ -34,6 +34,12 @@
 					"type": "string",
 					"source": "text",
 					"selector": ".provider-type__label"
+				},
+				"type": {
+					"type": "string",
+					"source": "attribute",
+					"selector": "input",
+					"attribute": "data-type"
 				}
 			},
 			"default": []
@@ -50,9 +56,10 @@
 			"fontSize": true
 		}
 	},
-	"icon": "edit-page",
+	"icon": "bank",
 	"textdomain": "fame_lahjoitukset",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./index.css",
+	"script": "file:./view.js",
 	"style": "file:./style-index.css"
 }

--- a/src/Blocks/donation-providers/block.json
+++ b/src/Blocks/donation-providers/block.json
@@ -3,9 +3,9 @@
 	"apiVersion": 3,
 	"name": "famehelsinki/donation-providers",
 	"version": "0.1.0",
-	"title": "Donation providers",
+	"title": "Payment providers",
 	"category": "widgets",
-	"description": "Allows selecting donation providers.",
+	"description": "Allows selecting payment providers.",
 	"parent": ["famehelsinki/donation-form"],
 	"usesContext": ["famehelsinki/donation-types"],
 	"attributes": {
@@ -17,7 +17,7 @@
 			"type": "string",
 			"source": "text",
 			"selector": "legend.fame-form__legend",
-			"default": "Provider type"
+			"default": "Payment provider"
 		},
 		"providers": {
 			"type": "array",

--- a/src/Blocks/donation-providers/edit.css
+++ b/src/Blocks/donation-providers/edit.css
@@ -1,0 +1,5 @@
+.payment-method-selector {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}

--- a/src/Blocks/donation-providers/edit.tsx
+++ b/src/Blocks/donation-providers/edit.tsx
@@ -1,109 +1,157 @@
-import React from 'react'
+import React, { useMemo, useEffect } from 'react'
 import { __ } from '@wordpress/i18n'
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor'
 import { PanelBody, Flex, CheckboxControl, TextControl, ToggleControl } from '@wordpress/components'
 import { EditProps } from '../common/types.ts'
 import { PROVIDERS, Provider } from '../common/Providers.ts'
+import { getDonationLabel } from '../common/donation-type.ts'
+
+export type FlatProvider = Provider & { type: string }
 
 export type Attributes = {
 	legend?: string
-	providers?: Provider[]
-	value?: string
+	providers?: FlatProvider[]
 	showLegend?: boolean
 }
 
-export default function Edit({ attributes, setAttributes }: EditProps<Attributes>) {
+export default function Edit({ attributes, setAttributes, context }: EditProps<Attributes>) {
 	const {
 		providers = [],
 		legend = __('Provider type', 'fame_lahjoitukset'),
 		showLegend = true,
 	} = attributes
 
-	const selected = new Set(providers.map(p => p.value))
+	const donationTypes: string[] = useMemo(() => {
+		return context['famehelsinki/donation-types'] || []
+	}, [context])
+	const blockProps = useBlockProps()
 
-	const toggleProvider = (value: string, checked: boolean) => {
-		let updated: Provider[]
+	// Remove providers which type is no longer selected
+	useEffect(() => {
+		const cleaned = providers.filter(p => donationTypes.includes(p.type))
+		if (cleaned.length !== providers.length) {
+			setAttributes({ providers: cleaned })
+		}
+	}, [donationTypes, providers, setAttributes])
 
-		if (checked && !selected.has(value)) {
-			const label = PROVIDERS.find(p => p.value === value)?.label || value
-			updated = [...providers, { value, label }]
-		} else if (!checked) {
-			updated = providers.filter(p => p.value !== value)
+	// Group by type
+	const grouped = providers.reduce<Record<string, FlatProvider[]>>((acc, p) => {
+		if (!acc[p.type]) acc[p.type] = []
+		acc[p.type].push(p)
+		return acc
+	}, {})
+
+	const updateProvider = (donationType: string, value: string, checked: boolean) => {
+		const current = grouped[donationType] ?? []
+		const exists = current.find(p => p.value === value)
+
+		let updated: FlatProvider[]
+
+		if (checked) {
+			if (exists) {
+				updated = current
+			} else {
+				const providerData = PROVIDERS.find(p => p.value === value)
+				if (!providerData) return
+
+				updated = [
+					...current,
+					{
+						...providerData,
+						type: donationType,
+					},
+				]
+			}
 		} else {
-			return
+			updated = current.filter(p => p.value !== value)
 		}
 
-		setAttributes({ providers: updated })
+		const newGrouped = { ...grouped, [donationType]: updated }
+
+		setAttributes({
+			providers: Object.entries(newGrouped).flatMap(([groupType, list]) =>
+				list.map(p => ({ ...p, type: groupType }))
+			),
+		})
 	}
 
-	const updateLabel = (value: string, newLabel: string) => {
-		const updated = providers.map(p => (p.value === value ? { ...p, label: newLabel } : p))
-		setAttributes({ providers: updated })
-	}
+	const updateLabel = (donationType: string, value: string, label: string) => {
+		const current = grouped[donationType] ?? []
+		const updated = current.map(p => (p.value === value ? { ...p, label } : p))
 
-	const visible = providers.length > 0
+		const newGrouped = { ...grouped, [donationType]: updated }
+
+		setAttributes({
+			providers: Object.entries(newGrouped).flatMap(([groupType, list]) =>
+				list.map(p => ({ ...p, type: groupType }))
+			),
+		})
+	}
 
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={__('Settings', 'fame_lahjoitukset')}>
-					<Flex direction="column" gap={2}>
-						{PROVIDERS.map(p => (
-							<CheckboxControl
-								key={p.value}
-								label={p.label}
-								checked={selected.has(p.value)}
-								onChange={checked => toggleProvider(p.value, checked)}
-							/>
-						))}
+				{donationTypes.map(donationType => {
+					const selected = new Set((grouped[donationType] ?? []).map(p => p.value))
+					return (
+						<PanelBody title={getDonationLabel(donationType)} key={donationType}>
+							<Flex direction="column" gap={2}>
+								{PROVIDERS.filter(p => p.types.includes(donationType)).map(p => (
+									<CheckboxControl
+										key={p.value}
+										label={p.label}
+										checked={selected.has(p.value)}
+										onChange={checked =>
+											updateProvider(donationType, p.value, checked)
+										}
+									/>
+								))}
 
-						{providers.map(p => (
-							<TextControl
-								key={p.value}
-								label={`${p.label} ${__('label', 'fame_lahjoitukset')}`}
-								value={p.label}
-								onChange={val => updateLabel(p.value, val)}
-							/>
-						))}
-
-						<ToggleControl
-							label={__('Show legend', 'fame_lahjoitukset')}
-							checked={showLegend}
-							onChange={checked => setAttributes({ showLegend: checked })}
-						/>
-
-						{visible && showLegend && (
-							<TextControl
-								label={__('Legend', 'fame_lahjoitukset')}
-								help={__('Description for screen readers.', 'fame_lahjoitukset')}
-								value={legend}
-								onChange={legend => setAttributes({ legend })}
-							/>
-						)}
-					</Flex>
+								{(grouped[donationType] ?? []).map(p => (
+									<TextControl
+										key={p.value}
+										label={`${p.label} ${__('label', 'fame_lahjoitukset')}`}
+										value={p.label}
+										onChange={val => updateLabel(donationType, p.value, val)}
+									/>
+								))}
+							</Flex>
+						</PanelBody>
+					)
+				})}
+				<PanelBody title={__('General settings', 'fame_lahjoitukset')}>
+					<ToggleControl
+						label={__('Show legend', 'fame_lahjoitukset')}
+						checked={showLegend}
+						onChange={checked => setAttributes({ showLegend: checked })}
+					/>
+					<TextControl
+						label={__('Legend', 'fame_lahjoitukset')}
+						value={legend}
+						onChange={value => setAttributes({ legend: value })}
+					/>
 				</PanelBody>
 			</InspectorControls>
 
-			<div {...useBlockProps()}>
+			<div {...blockProps}>
 				<fieldset className="payment-method-selector">
-					{showLegend && legend && (
-						<legend className="fame-form__legend">{legend}</legend>
+					{showLegend && <legend className="fame-form__legend">{legend}</legend>}
+					{donationTypes.map(type =>
+						(grouped[type] ?? []).map(p => (
+							<div key={`${type}-${p.value}`} data-type={type}>
+								<label htmlFor={`payment_method_${type}_${p.value}`}>
+									<input
+										type="radio"
+										id={`payment_method_${type}_${p.value}`}
+										name={`payment_method_${type}`}
+										value={p.value}
+										disabled
+									/>
+									<span className="provider-type__label">{p.label}</span>
+								</label>
+							</div>
+						))
 					)}
-
-					{providers.map(p => (
-						<div key={p.value}>
-							<label htmlFor={`payment_method_${p.value}`}>
-								<input
-									type="radio"
-									id={`payment_method_${p.value}`}
-									name="payment_method"
-									value={p.value}
-									disabled
-								/>
-								<span className="provider-type__label">{p.label}</span>
-							</label>
-						</div>
-					))}
 				</fieldset>
 			</div>
 		</>

--- a/src/Blocks/donation-providers/edit.tsx
+++ b/src/Blocks/donation-providers/edit.tsx
@@ -14,6 +14,12 @@ export type Attributes = {
 	showLegend?: boolean
 }
 
+/**
+ * The edit function describes the structure of your block in the context of the
+ * editor. This represents what the editor will render when the block is used.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#edit
+ */
 export default function Edit({ attributes, setAttributes, context }: EditProps<Attributes>) {
 	const {
 		providers = [],
@@ -82,8 +88,8 @@ export default function Edit({ attributes, setAttributes, context }: EditProps<A
 		const newGrouped = { ...grouped, [donationType]: updated }
 
 		setAttributes({
-			providers: Object.entries(newGrouped).flatMap(([groupType, list]) =>
-				list.map(p => ({ ...p, type: groupType }))
+			providers: Object.entries(newGrouped).flatMap(([key, list]) =>
+				list.map(p => ({ ...p, type: key }))
 			),
 		})
 	}

--- a/src/Blocks/donation-providers/edit.tsx
+++ b/src/Blocks/donation-providers/edit.tsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import { __ } from '@wordpress/i18n'
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor'
+import { PanelBody, Flex, CheckboxControl, TextControl, ToggleControl } from '@wordpress/components'
+import { EditProps } from '../common/types.ts'
+import { PROVIDERS, Provider } from '../common/Providers.ts'
+
+export type Attributes = {
+	legend?: string
+	providers?: Provider[]
+	value?: string
+	showLegend?: boolean
+}
+
+export default function Edit({ attributes, setAttributes }: EditProps<Attributes>) {
+	const {
+		providers = [],
+		legend = __('Provider type', 'fame_lahjoitukset'),
+		showLegend = true,
+	} = attributes
+
+	const selected = new Set(providers.map(p => p.value))
+
+	const toggleProvider = (value: string, checked: boolean) => {
+		let updated: Provider[]
+
+		if (checked && !selected.has(value)) {
+			const label = PROVIDERS.find(p => p.value === value)?.label || value
+			updated = [...providers, { value, label }]
+		} else if (!checked) {
+			updated = providers.filter(p => p.value !== value)
+		} else {
+			return
+		}
+
+		setAttributes({ providers: updated })
+	}
+
+	const updateLabel = (value: string, newLabel: string) => {
+		const updated = providers.map(p => (p.value === value ? { ...p, label: newLabel } : p))
+		setAttributes({ providers: updated })
+	}
+
+	const visible = providers.length > 0
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={__('Settings', 'fame_lahjoitukset')}>
+					<Flex direction="column" gap={2}>
+						{PROVIDERS.map(p => (
+							<CheckboxControl
+								key={p.value}
+								label={p.label}
+								checked={selected.has(p.value)}
+								onChange={checked => toggleProvider(p.value, checked)}
+							/>
+						))}
+
+						{providers.map(p => (
+							<TextControl
+								key={p.value}
+								label={`${p.label} ${__('label', 'fame_lahjoitukset')}`}
+								value={p.label}
+								onChange={val => updateLabel(p.value, val)}
+							/>
+						))}
+
+						<ToggleControl
+							label={__('Show legend', 'fame_lahjoitukset')}
+							checked={showLegend}
+							onChange={checked => setAttributes({ showLegend: checked })}
+						/>
+
+						{visible && showLegend && (
+							<TextControl
+								label={__('Legend', 'fame_lahjoitukset')}
+								help={__('Description for screen readers.', 'fame_lahjoitukset')}
+								value={legend}
+								onChange={legend => setAttributes({ legend })}
+							/>
+						)}
+					</Flex>
+				</PanelBody>
+			</InspectorControls>
+
+			<div {...useBlockProps()}>
+				<fieldset className="payment-method-selector">
+					{showLegend && legend && (
+						<legend className="fame-form__legend">{legend}</legend>
+					)}
+
+					{providers.map(p => (
+						<div key={p.value}>
+							<label htmlFor={`payment_method_${p.value}`}>
+								<input
+									type="radio"
+									id={`payment_method_${p.value}`}
+									name="payment_method"
+									value={p.value}
+									disabled
+								/>
+								<span className="provider-type__label">{p.label}</span>
+							</label>
+						</div>
+					))}
+				</fieldset>
+			</div>
+		</>
+	)
+}

--- a/src/Blocks/donation-providers/edit.tsx
+++ b/src/Blocks/donation-providers/edit.tsx
@@ -32,6 +32,25 @@ export default function Edit({ attributes, setAttributes, context }: EditProps<A
 	}, [context])
 	const blockProps = useBlockProps()
 
+	// Adds default prviders (first from array providers)
+	useEffect(() => {
+		const missingTypes = donationTypes.filter(type => !providers.some(p => p.type === type))
+
+		if (missingTypes.length === 0) return
+
+		const defaults = missingTypes
+			.map(type => {
+				const match = PROVIDERS.find(p => p.types.includes(type))
+				if (!match) return null
+				return { ...match, type }
+			})
+			.filter(Boolean) as FlatProvider[]
+
+		if (defaults.length > 0) {
+			setAttributes({ providers: [...providers, ...defaults] })
+		}
+	}, [donationTypes, providers, setAttributes])
+
 	// Remove providers which type is no longer selected
 	useEffect(() => {
 		const cleaned = providers.filter(p => donationTypes.includes(p.type))
@@ -140,25 +159,27 @@ export default function Edit({ attributes, setAttributes, context }: EditProps<A
 			</InspectorControls>
 
 			<div {...blockProps}>
-				<fieldset className="payment-method-selector">
-					{showLegend && <legend className="fame-form__legend">{legend}</legend>}
-					{donationTypes.map(type =>
-						(grouped[type] ?? []).map(p => (
-							<div key={`${type}-${p.value}`} data-type={type}>
-								<label htmlFor={`payment_method_${type}_${p.value}`}>
-									<input
-										type="radio"
-										id={`payment_method_${type}_${p.value}`}
-										name={`payment_method_${type}`}
-										value={p.value}
-										disabled
-									/>
-									<span className="provider-type__label">{p.label}</span>
-								</label>
-							</div>
-						))
-					)}
-				</fieldset>
+				{Object.entries(grouped).map(([type, list]) => {
+					return (
+						<fieldset key={type} className="payment-method-selector" data-type={type}>
+							{showLegend && <legend className="fame-form__legend">{legend}</legend>}
+							{list.map(p => (
+								<div key={`${type}-${p.value}`} data-type={type}>
+									<label htmlFor={`payment_method_${type}_${p.value}`}>
+										<input
+											type="radio"
+											id={`payment_method_${type}_${p.value}`}
+											name={`payment_method_${type}`}
+											value={p.value}
+											disabled
+										/>
+										<span className="provider-type__label">{p.label}</span>
+									</label>
+								</div>
+							))}
+						</fieldset>
+					)
+				})}
 			</div>
 		</>
 	)

--- a/src/Blocks/donation-providers/index.ts
+++ b/src/Blocks/donation-providers/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Registers a new block provided a unique name and an object defining its behavior.
+ *
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ */
+import { registerBlockType } from '@wordpress/blocks'
+
+/**
+ * Internal dependencies
+ */
+import Edit from './edit'
+import save from './save'
+import metadata from './block.json'
+import './edit.css'
+
+/**
+ * Every block starts by registering a new block type definition.
+ *
+ * @see https://developer.wordpress.org/block-editor/developers/block-api/#registering-a-block
+ */
+registerBlockType(metadata.name, {
+	/**
+	 * @see ./edit.js
+	 */
+	edit: Edit,
+	/**
+	 * @see ./save.js
+	 */
+	save,
+} as any)

--- a/src/Blocks/donation-providers/index.ts
+++ b/src/Blocks/donation-providers/index.ts
@@ -12,6 +12,7 @@ import Edit from './edit'
 import save from './save'
 import metadata from './block.json'
 import './edit.css'
+import './view'
 
 /**
  * Every block starts by registering a new block type definition.

--- a/src/Blocks/donation-providers/save.tsx
+++ b/src/Blocks/donation-providers/save.tsx
@@ -4,6 +4,13 @@ import { SaveProps } from '../common/types.ts'
 
 type Provider = { value: string; label: string }
 
+/**
+ * The save function defines the way in which the different attributes should
+ * be combined into the final markup, which is then serialized by the block
+ * editor into `post_content`.
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/block-api/block-edit-save/#save
+ */
 export default function Save({
 	attributes,
 }: SaveProps<{
@@ -20,7 +27,11 @@ export default function Save({
 				{showLegend && <legend className="fame-form__legend">{legend}</legend>}
 
 				{flatProviders.map(p => (
-					<div key={`${p.type}-${p.value}`} data-type={p.type}>
+					<div
+						className="fame-form__group"
+						key={`${p.type}-${p.value}`}
+						data-type={p.type}
+					>
 						<label htmlFor={`payment_method_${p.type}_${p.value}`}>
 							<input
 								type="radio"

--- a/src/Blocks/donation-providers/save.tsx
+++ b/src/Blocks/donation-providers/save.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useBlockProps } from '@wordpress/block-editor'
 import { SaveProps } from '../common/types.ts'
 
-type Provider = { value: string; label: string }
+type Provider = { value: string; label: string; type: string }
 
 /**
  * The save function defines the way in which the different attributes should
@@ -14,38 +14,53 @@ type Provider = { value: string; label: string }
 export default function Save({
 	attributes,
 }: SaveProps<{
-	providers?: Record<string, Provider[]>
+	providers?: Provider[]
 	legend?: string
 	showLegend?: boolean
 }>): React.JSX.Element {
-	const { providers = {}, legend = 'Provider type', showLegend = true } = attributes
-	const flatProviders = Array.isArray(providers) ? providers : []
+	const { providers = [], legend = 'Provider type', showLegend = true } = attributes
+	const blockProps = useBlockProps.save()
+
+	const grouped = providers.reduce<Record<string, Provider[]>>((acc, p) => {
+		if (!acc[p.type]) acc[p.type] = []
+		acc[p.type].push(p)
+		return acc
+	}, {})
 
 	return (
-		<div {...useBlockProps.save()}>
-			<fieldset className="payment-method-selector">
-				{showLegend && <legend className="fame-form__legend">{legend}</legend>}
-
-				{flatProviders.map(p => (
-					<div
-						className="fame-form__group"
-						key={`${p.type}-${p.value}`}
-						data-type={p.type}
-					>
-						<label htmlFor={`payment_method_${p.type}_${p.value}`}>
-							<input
-								type="radio"
-								id={`payment_method_${p.type}_${p.value}`}
-								name="provider"
-								value={p.value}
-								data-type={p.type}
-								required
-							/>
-							<span className="provider-type__label">{p.label}</span>
-						</label>
-					</div>
-				))}
-			</fieldset>
+		<div {...blockProps}>
+			{Object.entries(grouped).map(([type, list]) => (
+				<fieldset className="payment-method-selector" data-type={type} key={type}>
+					{showLegend && <legend className="fame-form__legend">{legend}</legend>}
+					{list.length === 1 && (
+						<input
+							type="hidden"
+							name="provider"
+							value={list[0].value}
+							data-type={list[0].type}
+						/>
+					)}
+					{list.map(provider => (
+						<div
+							className="fame-form__group"
+							key={`${provider.type}-${provider.value}`}
+							data-type={provider.type}
+						>
+							<label htmlFor={`payment_method_${provider.type}_${provider.value}`}>
+								<input
+									type="radio"
+									id={`payment_method_${provider.type}_${provider.value}`}
+									name="provider"
+									value={provider.value}
+									data-type={provider.type}
+									required={true}
+								/>
+								<span className="provider-type__label">{provider.label}</span>
+							</label>
+						</div>
+					))}
+				</fieldset>
+			))}
 		</div>
 	)
 }

--- a/src/Blocks/donation-providers/save.tsx
+++ b/src/Blocks/donation-providers/save.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { useBlockProps } from '@wordpress/block-editor'
+import { SaveProps } from '../common/types.ts'
+
+type ProviderData = { value: string; label: string }
+
+export default function Save({
+	attributes,
+}: SaveProps<{
+	providers?: ProviderData[]
+	legend?: string
+	showLegend?: boolean
+}>): React.JSX.Element {
+	const { providers = [], legend = 'Provider type', showLegend = true } = attributes
+
+	return (
+		<div {...useBlockProps.save()}>
+			<fieldset className="payment-method-selector">
+				{showLegend && legend && <legend className="fame-form__legend">{legend}</legend>}
+				{providers.map(p => (
+					<div key={p.value}>
+						<label htmlFor={`payment_method_${p.value}`}>
+							<input
+								type="radio"
+								id={`payment_method_${p.value}`}
+								name="payment_method"
+								value={p.value}
+								required
+							/>
+							<span className="provider-type__label">{p.label}</span>
+						</label>
+					</div>
+				))}
+			</fieldset>
+		</div>
+	)
+}

--- a/src/Blocks/donation-providers/save.tsx
+++ b/src/Blocks/donation-providers/save.tsx
@@ -2,29 +2,32 @@ import React from 'react'
 import { useBlockProps } from '@wordpress/block-editor'
 import { SaveProps } from '../common/types.ts'
 
-type ProviderData = { value: string; label: string }
+type Provider = { value: string; label: string }
 
 export default function Save({
 	attributes,
 }: SaveProps<{
-	providers?: ProviderData[]
+	providers?: Record<string, Provider[]>
 	legend?: string
 	showLegend?: boolean
 }>): React.JSX.Element {
-	const { providers = [], legend = 'Provider type', showLegend = true } = attributes
+	const { providers = {}, legend = 'Provider type', showLegend = true } = attributes
+	const flatProviders = Array.isArray(providers) ? providers : []
 
 	return (
 		<div {...useBlockProps.save()}>
 			<fieldset className="payment-method-selector">
-				{showLegend && legend && <legend className="fame-form__legend">{legend}</legend>}
-				{providers.map(p => (
-					<div key={p.value}>
-						<label htmlFor={`payment_method_${p.value}`}>
+				{showLegend && <legend className="fame-form__legend">{legend}</legend>}
+
+				{flatProviders.map(p => (
+					<div key={`${p.type}-${p.value}`} data-type={p.type}>
+						<label htmlFor={`payment_method_${p.type}_${p.value}`}>
 							<input
 								type="radio"
-								id={`payment_method_${p.value}`}
-								name="payment_method"
+								id={`payment_method_${p.type}_${p.value}`}
+								name="provider"
 								value={p.value}
+								data-type={p.type}
 								required
 							/>
 							<span className="provider-type__label">{p.label}</span>

--- a/src/Blocks/donation-providers/view.ts
+++ b/src/Blocks/donation-providers/view.ts
@@ -11,7 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
 		if (!selectedType) return
 
 		providerRows.forEach(row => {
-			row.style.display = row.dataset.type === selectedType ? 'block' : 'none'
+			row.style.display = row.dataset.type === selectedType ? 'inline-block' : 'none'
 		})
 	}
 

--- a/src/Blocks/donation-providers/view.ts
+++ b/src/Blocks/donation-providers/view.ts
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded', () => {
+	const typeInputs = document.querySelectorAll<HTMLInputElement>('input[name="type"]')
+	const providerRows = document.querySelectorAll<HTMLElement>(
+		'.payment-method-selector [data-type]'
+	)
+
+	const updateVisibleProviders = () => {
+		const selectedType = document.querySelector<HTMLInputElement>(
+			'input[name="type"]:checked'
+		)?.value
+		if (!selectedType) return
+
+		providerRows.forEach(row => {
+			row.style.display = row.dataset.type === selectedType ? 'block' : 'none'
+		})
+	}
+
+	typeInputs.forEach(input => input.addEventListener('change', updateVisibleProviders))
+	updateVisibleProviders()
+})

--- a/src/Blocks/donation-providers/view.ts
+++ b/src/Blocks/donation-providers/view.ts
@@ -1,20 +1,5 @@
+import ProviderHandler from './ProviderHandler'
+
 document.addEventListener('DOMContentLoaded', () => {
-	const typeInputs = document.querySelectorAll<HTMLInputElement>('input[name="type"]')
-	const providerRows = document.querySelectorAll<HTMLElement>(
-		'.payment-method-selector [data-type]'
-	)
-
-	const updateVisibleProviders = () => {
-		const selectedType = document.querySelector<HTMLInputElement>(
-			'input[name="type"]:checked'
-		)?.value
-		if (!selectedType) return
-
-		providerRows.forEach(row => {
-			row.style.display = row.dataset.type === selectedType ? 'inline-block' : 'none'
-		})
-	}
-
-	typeInputs.forEach(input => input.addEventListener('change', updateVisibleProviders))
-	updateVisibleProviders()
+	new ProviderHandler()
 })


### PR DESCRIPTION
https://famehelsinki.atlassian.net/browse/LHJ-75
Implements block to select payment provider.

**To test**

- install and enable plugin and use staging url  
- npm run lint:css and npm run lint:js should not give any errors or warnigs from donation-providers block

- add page and select block Lahjoitin

- select single and recurring donation types etc

- should look like this (In the editor view single and recurring donation providers are not filtered so they are shown same time. What selected for single and recurring can be seen in side panel.)

![image](https://github.com/user-attachments/assets/e534cda7-0ffc-46c7-816c-255b2eb0c285)

- you should be able to change provider labels and legend label and add/remove payment providers. 

- test for example single and mobilepay option . After submit it should open payment provider MobilePay. Test also paytrail.