### PR TITLE
Hide amount controls when no amount buttons are enabled

### DIFF
--- a/src/Blocks/donation-amounts/AmountSettingsControl.tsx
+++ b/src/Blocks/donation-amounts/AmountSettingsControl.tsx
@@ -41,18 +41,26 @@ const AmountSettingsControl: FC<Props> = ({ settings, other, visible, onChange }
 						onChange({ ...settings, defaultAmount: formatAmount(value, 0) })
 					}
 				/>
-				<TextControl
-					label={__('Min Amount', 'fame_lahjoitukset')}
-					help={__('Minimum amount for other amount field.', 'fame_lahjoitukset')}
-					value={(settings.minAmount ?? MIN_AMOUNT).toString()}
-					onChange={value => onChange({ ...settings, minAmount: formatAmount(value, 0) })}
-				/>
-				<TextControl
-					label={__('Max Amount', 'fame_lahjoitukset')}
-					help={__('Maximum amount for other amount field.', 'fame_lahjoitukset')}
-					value={(settings.maxAmount ?? MAX_AMOUNT).toString()}
-					onChange={value => onChange({ ...settings, maxAmount: formatAmount(value, 0) })}
-				/>
+				{other && (
+					<>
+						<TextControl
+							label={__('Min Amount', 'fame_lahjoitukset')}
+							help={__('Minimum amount for other amount field.', 'fame_lahjoitukset')}
+							value={(settings.minAmount ?? MIN_AMOUNT).toString()}
+							onChange={value =>
+								onChange({ ...settings, minAmount: formatAmount(value, 0) })
+							}
+						/>
+						<TextControl
+							label={__('Max Amount', 'fame_lahjoitukset')}
+							help={__('Maximum amount for other amount field.', 'fame_lahjoitukset')}
+							value={(settings.maxAmount ?? MAX_AMOUNT).toString()}
+							onChange={value =>
+								onChange({ ...settings, maxAmount: formatAmount(value, 0) })
+							}
+						/>
+					</>
+				)}
 			</>
 		) : (
 			<RadioControl

--- a/src/Blocks/donation-amounts/edit.tsx
+++ b/src/Blocks/donation-amounts/edit.tsx
@@ -203,14 +203,19 @@ export default function Edit({
 						value={legend ?? DEFAULT_LEGEND}
 						onChange={value => setAttributes({ legend: value })}
 					/>
-					<RangeControl
-						label={__('Amount columns', 'fame_lahjoitukset')}
-						help={__('Choose 1–3 columns for the form layout.', 'fame_lahjoitukset')}
-						min={1}
-						max={3}
-						value={colsAmounts}
-						onChange={(v?: number) => setAttributes({ colsAmounts: v ?? 3 })}
-					/>
+					{settings.some(({ amounts }) => amounts?.length) && (
+						<RangeControl
+							label={__('Amount columns', 'fame_lahjoitukset')}
+							help={__(
+								'Choose 1–3 columns for the form layout.',
+								'fame_lahjoitukset'
+							)}
+							min={1}
+							max={3}
+							value={colsAmounts}
+							onChange={(v?: number) => setAttributes({ colsAmounts: v ?? 3 })}
+						/>
+					)}
 					<Flex justify="initial">
 						<Button
 							variant="primary"


### PR DESCRIPTION
Gate the "Amount columns" control on the presence of amount buttons, and hide the Min/Max amount fields unless the other amount field is enabled