### PR TITLE
LHJ-154 Optionally show max value

### DIFF
--- a/languages/fame_lahjoitukset-fi_FI.po
+++ b/languages/fame_lahjoitukset-fi_FI.po
@@ -577,3 +577,13 @@ msgstr "Lomaketoiminnot"
 msgctxt "block description"
 msgid "Adds form controls."
 msgstr "Lisää lomaketoiminnot."
+
+#: build/Blocks/donation-amounts/index.js:1
+#: src/Blocks/donation-amounts/AmountSettingsControl.tsx:63
+msgid "Show maximum amount to donor"
+msgstr "Näytä suurin summa lahjoittajalle"
+
+#: build/Blocks/donation-amounts/index.js:1
+#: src/Blocks/donation-amounts/AmountSettingsControl.tsx:65
+msgid "Show the maximum amount in the helper text under the other amount field."
+msgstr "Näytä suurin summa muu summa -kentän alla olevassa ohjetekstissä."

--- a/languages/fame_lahjoitukset-sv_SE.po
+++ b/languages/fame_lahjoitukset-sv_SE.po
@@ -577,3 +577,13 @@ msgstr "Formulärkontroller"
 msgctxt "block description"
 msgid "Adds form controls."
 msgstr "Lägger till formulärkontroller."
+
+#: build/Blocks/donation-amounts/index.js:1
+#: src/Blocks/donation-amounts/AmountSettingsControl.tsx:63
+msgid "Show maximum amount to donor"
+msgstr "Visa högsta belopp för donatorn"
+
+#: build/Blocks/donation-amounts/index.js:1
+#: src/Blocks/donation-amounts/AmountSettingsControl.tsx:65
+msgid "Show the maximum amount in the helper text under the other amount field."
+msgstr "Visa högsta belopp i hjälptexten under fältet för annat belopp."

--- a/languages/fame_lahjoitukset.pot
+++ b/languages/fame_lahjoitukset.pot
@@ -590,3 +590,13 @@ msgstr ""
 msgctxt "block description"
 msgid "Adds form controls."
 msgstr ""
+
+#: build/Blocks/donation-amounts/index.js:1
+#: src/Blocks/donation-amounts/AmountSettingsControl.tsx:63
+msgid "Show maximum amount to donor"
+msgstr ""
+
+#: build/Blocks/donation-amounts/index.js:1
+#: src/Blocks/donation-amounts/AmountSettingsControl.tsx:65
+msgid "Show the maximum amount in the helper text under the other amount field."
+msgstr ""

--- a/src/Blocks/common/donation-amount.ts
+++ b/src/Blocks/common/donation-amount.ts
@@ -18,6 +18,7 @@ export type AmountSetting = {
 	amounts?: Amount[]
 	minAmount?: number | string
 	maxAmount?: number | string
+	showMaxAmount?: boolean
 }
 
 export const formatAmount = (amount?: string | number, def = DEFAULT_AMOUNT) =>

--- a/src/Blocks/donation-amounts/AmountSettingsControl.tsx
+++ b/src/Blocks/donation-amounts/AmountSettingsControl.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react'
 import { __ } from '@wordpress/i18n'
-import { RadioControl, TextControl } from '@wordpress/components'
+import { RadioControl, TextControl, ToggleControl } from '@wordpress/components'
 import {
 	DEFAULT_AMOUNT,
 	DEFAULT_UNIT,
@@ -58,6 +58,15 @@ const AmountSettingsControl: FC<Props> = ({ settings, other, visible, onChange }
 							onChange={value =>
 								onChange({ ...settings, maxAmount: formatAmount(value, 0) })
 							}
+						/>
+						<ToggleControl
+							label={__('Show maximum amount to donor', 'fame_lahjoitukset')}
+							help={__(
+								'Show the maximum amount in the helper text under the other amount field.',
+								'fame_lahjoitukset'
+							)}
+							checked={!!settings.showMaxAmount}
+							onChange={value => onChange({ ...settings, showMaxAmount: value })}
 						/>
 					</>
 				)}

--- a/src/Blocks/donation-amounts/EditContent.tsx
+++ b/src/Blocks/donation-amounts/EditContent.tsx
@@ -58,9 +58,13 @@ const EditContent: FC<Props> = ({ current, other, otherLabel, setAttributes }) =
 					<span className="donation-amounts__minmax">
 						{__('Min', 'fame_lahjoitukset')} {current.minAmount ?? MIN_AMOUNT}
 						{current.unit ?? ''}
-						{' – '}
-						{__('Max', 'fame_lahjoitukset')} {current.maxAmount ?? MAX_AMOUNT}
-						{current.unit ?? ''}
+						{current.showMaxAmount && (
+							<>
+								{' – '}
+								{__('Max', 'fame_lahjoitukset')} {current.maxAmount ?? MAX_AMOUNT}
+								{current.unit ?? ''}
+							</>
+						)}
 					</span>
 				</div>
 			)}

--- a/src/Blocks/donation-amounts/block.json
+++ b/src/Blocks/donation-amounts/block.json
@@ -19,6 +19,7 @@
 					"defaultAmount": 10,
 					"minAmount": 10,
 					"maxAmount": 10000,
+					"showMaxAmount": false,
 					"unit": "€",
 					"amounts": [{ "value": 10 }, { "value": 20 }, { "value": 30 }]
 				},
@@ -28,6 +29,7 @@
 					"defaultAmount": 10,
 					"minAmount": 10,
 					"maxAmount": 10000,
+					"showMaxAmount": false,
 					"unit": "€",
 					"amounts": [{ "value": 10 }, { "value": 20 }, { "value": 30 }]
 				}

--- a/src/Blocks/donation-amounts/edit.tsx
+++ b/src/Blocks/donation-amounts/edit.tsx
@@ -133,6 +133,7 @@ export default function Edit({
 					if (setting.minAmount === null) setting.minAmount = MIN_AMOUNT
 					if (setting.maxAmount === null) setting.maxAmount = MAX_AMOUNT
 					if (setting.unit === null) setting.unit = DEFAULT_UNIT
+					if (setting.showMaxAmount === undefined) setting.showMaxAmount = false
 					return setting
 				}) ?? []
 
@@ -147,6 +148,7 @@ export default function Edit({
 				unit: DEFAULT_UNIT,
 				minAmount: MIN_AMOUNT,
 				maxAmount: MAX_AMOUNT,
+				showMaxAmount: false,
 			})
 		}
 

--- a/src/Blocks/donation-amounts/render.php
+++ b/src/Blocks/donation-amounts/render.php
@@ -159,6 +159,7 @@ endif;
     $unit          = $str($type_setting['unit'] ?? null, $DEFAULT_UNIT);
     $min_amount    = $int($type_setting['minAmount'] ?? null, $MIN_AMOUNT);
     $max_amount    = $int($type_setting['maxAmount'] ?? null, $MAX_AMOUNT);
+    $show_max_amount = !empty($type_setting['showMaxAmount']);
     $default_euros = $int($type_setting['defaultAmount'] ?? null, $DEFAULT_AMOUNT);
 
     $amounts = isset($type_setting['amounts']) && is_array($type_setting['amounts']) ? $type_setting['amounts'] : [];
@@ -232,11 +233,14 @@ endif;
             <?php
             echo esc_html__('Min', 'fame_lahjoitukset') . ' '
               . esc_html(number_format((float) $min_amount, 0, ',', ' '))
-              . esc_html($unit)
-              . ' – '
-              . esc_html__('Max', 'fame_lahjoitukset') . ' '
-              . esc_html(number_format((float) $max_amount, 0, ',', ' '))
               . esc_html($unit);
+
+            if ($show_max_amount) {
+              echo ' – '
+                . esc_html__('Max', 'fame_lahjoitukset') . ' '
+                . esc_html(number_format((float) $max_amount, 0, ',', ' '))
+                . esc_html($unit);
+            }
             ?>
           </span>
         </div>

--- a/src/Blocks/donation-campaigns/render.php
+++ b/src/Blocks/donation-campaigns/render.php
@@ -20,9 +20,21 @@ $campaigns = isset($attributes['campaigns']) && is_array($attributes['campaigns'
   ? $attributes['campaigns']
   : [];
 
-if (!$show || count($campaigns) <= 1) {
+$campaigns = array_values(array_filter(array_map(static function ($campaign): string {
+  return trim((string) $campaign);
+}, $campaigns), static function (string $campaign): bool {
+  return $campaign !== '';
+}));
+
+if (!$show || count($campaigns) === 0) {
   return;
 }
+
+if (count($campaigns) === 1) : ?>
+  <input type="hidden" name="campaign" value="<?php echo esc_attr($campaigns[0]); ?>" />
+<?php
+  return;
+endif;
 
 $showLabel = array_key_exists('showLabel', $attributes) ? (bool) $attributes['showLabel'] : true;
 $label     = isset($attributes['label']) && trim((string) $attributes['label']) !== ''
@@ -42,16 +54,13 @@ $wrapper_attrs = get_block_wrapper_attributes([
   <?php endif; ?>
 
   <select name="campaign" id="campaign" class="fame-form__input">
-    <option value="" disabled selected>
+    <option value="" selected>
       <?php echo esc_html__('Select campaign', 'fame_lahjoitukset'); ?>
     </option>
 
-    <?php foreach ($campaigns as $campaign) :
-      $value = trim((string) $campaign);
-      if ($value === '') continue;
-    ?>
-      <option value="<?php echo esc_attr($value); ?>">
-        <?php echo esc_html($value); ?>
+    <?php foreach ($campaigns as $campaign) : ?>
+      <option value="<?php echo esc_attr($campaign); ?>">
+        <?php echo esc_html($campaign); ?>
       </option>
     <?php endforeach; ?>
   </select>

--- a/src/Blocks/donation-form/view/FormHandler.ts
+++ b/src/Blocks/donation-form/view/FormHandler.ts
@@ -244,6 +244,7 @@ export default class FormHandler {
 
 		const formData = new FormData(this.#form)
 		const data = Object.fromEntries(formData)
+		this.#removeEmptyOptionalFields(data)
 		const url = this.getSubmitUrl()
 
 		// Allow plugins to alter form data.
@@ -435,6 +436,12 @@ export default class FormHandler {
 		}
 
 		return this.#translations[name]?.[getErrorType(validity)] ?? 'Invalid value'
+	}
+
+	#removeEmptyOptionalFields(data: Record<string, FormDataEntryValue>) {
+		if (data.campaign === '') {
+			delete data.campaign
+		}
 	}
 
 	/**


### PR DESCRIPTION
- Add an editor toggle for showing the maximum amount helper text to donors
- Keep the minimum amount helper text visible by default
- Keep maximum amount validation active even when the maximum helper text is hidden
- Do not send an empty `campaign` value in the donation payload
- Use a hidden campaign field when only one campaign is configured
- Add Finnish and Swedish translations for the new maximum amount toggle texts