### PR TITLE
Fix i18n build scripts to include aliases for translation files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
 	"main": "build/index.js",
 	"scripts": {
 		"build": "wp-scripts build",
-		"build:i18n": "npm run i18n:mo && npm run i18n:json",
+		"build:i18n": "npm run i18n:mo && npm run i18n:mo:aliases && npm run i18n:json",
 		"i18n:pot": "npm run build && wp i18n make-pot . languages/fame_lahjoitukset.pot --domain=fame_lahjoitukset --exclude=node_modules,vendor,tests,.git",
 		"i18n:mo": "wp i18n make-mo languages languages",
 		"i18n:json": "wp i18n make-json languages languages --no-purge",
-		"i18n": "npm run i18n:pot && npm run i18n:mo && npm run i18n:json",
+		"i18n": "npm run i18n:pot && npm run i18n:mo && npm run i18n:mo:aliases && npm run i18n:json",
 		"format": "wp-scripts format src",
 		"lint:css": "wp-scripts lint-style",
 		"lint:js": "wp-scripts lint-js",
@@ -19,7 +19,8 @@
 		"packages-update": "wp-scripts packages-update",
 		"plugin-zip": "wp-scripts plugin-zip",
 		"dev": "wp-scripts start",
-		"start": "npm run start"
+		"start": "npm run start",
+		"i18n:mo:aliases": "cp languages/fame_lahjoitukset-fi_FI.mo languages/fame_lahjoitukset-fi.mo && cp languages/fame_lahjoitukset-sv_SE.mo languages/fame_lahjoitukset-sv.mo"
 	},
 	"devDependencies": {
 		"@jest/globals": "^30.3.0",


### PR DESCRIPTION
- Generate short-locale `.mo` aliases for PHP translations
- Ensure frontend PHP-rendered strings translate correctly when WordPress uses locales like `fi` instead of `fi_FI`