### PR TITLE
Provider-unavailable-submit-state

### DIFF
--- a/languages/fame_lahjoitukset-fi_FI.po
+++ b/languages/fame_lahjoitukset-fi_FI.po
@@ -587,3 +587,8 @@ msgstr "Näytä suurin summa lahjoittajalle"
 #: src/Blocks/donation-amounts/AmountSettingsControl.tsx:65
 msgid "Show the maximum amount in the helper text under the other amount field."
 msgstr "Näytä suurin summa muu summa -kentän alla olevassa ohjetekstissä."
+
+#: build/Blocks/donation-providers/render.php:95
+#: src/Blocks/donation-providers/render.php:95
+msgid "Payment methods are currently unavailable. Please try again later."
+msgstr "Maksutavat eivät ole juuri nyt saatavilla. Yritä myöhemmin uudelleen."

--- a/languages/fame_lahjoitukset-sv_SE.po
+++ b/languages/fame_lahjoitukset-sv_SE.po
@@ -587,3 +587,8 @@ msgstr "Visa högsta belopp för donatorn"
 #: src/Blocks/donation-amounts/AmountSettingsControl.tsx:65
 msgid "Show the maximum amount in the helper text under the other amount field."
 msgstr "Visa högsta belopp i hjälptexten under fältet för annat belopp."
+
+#: build/Blocks/donation-providers/render.php:95
+#: src/Blocks/donation-providers/render.php:95
+msgid "Payment methods are currently unavailable. Please try again later."
+msgstr "Betalningsmetoderna är inte tillgängliga just nu. Försök igen senare."

--- a/languages/fame_lahjoitukset.pot
+++ b/languages/fame_lahjoitukset.pot
@@ -600,3 +600,8 @@ msgstr ""
 #: src/Blocks/donation-amounts/AmountSettingsControl.tsx:65
 msgid "Show the maximum amount in the helper text under the other amount field."
 msgstr ""
+
+#: build/Blocks/donation-providers/render.php:95
+#: src/Blocks/donation-providers/render.php:95
+msgid "Payment methods are currently unavailable. Please try again later."
+msgstr ""

--- a/src/Blocks/donation-form/view.css
+++ b/src/Blocks/donation-form/view.css
@@ -375,6 +375,19 @@ label {
 	background: color-mix(in srgb, var(--primary-color) var(--hover-lighten), transparent calc(100% - var(--hover-lighten)));
 }
 
+.wp-block-famehelsinki-donation-form .fame-form__notice {
+	width: 100%;
+	padding: 12px 16px;
+	border: var(--border-width, 1px) solid var(--third-color, #444);
+	border-radius: var(--border-radius);
+	color: var(--third-color, #444);
+}
+
+.wp-block-famehelsinki-donation-form .fame-form__notice--warning {
+	border-color: var(--fame-clr-danger);
+	color: var(--fame-clr-danger);
+}
+
 .wp-block-famehelsinki-donation-form
 .wp-block-famehelsinki-donation-providers
 .fame-form__check-input:checked + .provider-type__label {

--- a/src/Blocks/donation-form/view/AmountHandler.ts
+++ b/src/Blocks/donation-form/view/AmountHandler.ts
@@ -62,7 +62,7 @@ export class AmountWrapper {
 			this.#clearError(this.#other)
 		}
 
-		this.#setSubmitDisabled(false)
+		this.#notifyValidityChange(false)
 	}
 
 	/**
@@ -182,17 +182,13 @@ export class AmountWrapper {
 		return other instanceof HTMLInputElement ? other : null
 	}
 
-	#setSubmitDisabled(disabled: boolean) {
-		const form = this.#wrapper.closest('form')
-		if (!form) return
-
-		// Primary: your control block button
-		const btn = form.querySelector('.fame-form__controls .wp-element-button')
-		if (btn instanceof HTMLButtonElement) {
-			btn.disabled = disabled
-			if (disabled) btn.setAttribute('aria-disabled', 'true')
-			else btn.removeAttribute('aria-disabled')
-		}
+	#notifyValidityChange(invalid: boolean) {
+		this.#wrapper.dispatchEvent(
+			new CustomEvent('fame-lahjoitukset-amount-validity', {
+				bubbles: true,
+				detail: { invalid },
+			})
+		)
 	}
 
 	#getUnit(input: HTMLInputElement) {
@@ -242,7 +238,7 @@ export class AmountWrapper {
 
 		if (!Number.isNaN(min) && amount < min) {
 			this.#invalidOther = true
-			this.#setSubmitDisabled(true)
+			this.#notifyValidityChange(true)
 			this.#showError(target, this.#messages.min(min, unit))
 			return
 		}
@@ -251,14 +247,14 @@ export class AmountWrapper {
 
 		if (!Number.isNaN(max) && amount > max) {
 			this.#invalidOther = true
-			this.#setSubmitDisabled(true)
+			this.#notifyValidityChange(true)
 			this.#showError(target, this.#messages.max(max, unit))
 			return
 		}
 
 		this.#invalidOther = false
 		this.#clearError(target)
-		this.#setSubmitDisabled(false)
+		this.#notifyValidityChange(false)
 
 		// Select radiobuttons that have the selected amount.
 		this.#buttons.forEach(button => {
@@ -279,7 +275,7 @@ export class AmountWrapper {
 			this.#invalidOther = false
 			this.#clearError(this.#other)
 			this.#other.value = amount
-			this.#setSubmitDisabled(false)
+			this.#notifyValidityChange(false)
 		}
 
 		this.#onChange(parseInt(amount))
@@ -295,6 +291,10 @@ export default class AmountHandler {
 
 	get amount() {
 		return parseInt(this.#amount.value) / 100
+	}
+
+	get invalid() {
+		return this.#isInvalid()
 	}
 
 	set amount(value: number) {

--- a/src/Blocks/donation-form/view/FormHandler.test.ts
+++ b/src/Blocks/donation-form/view/FormHandler.test.ts
@@ -25,6 +25,35 @@ describe('FormHandler', () => {
 		expect(form.addEventListener).toHaveBeenCalledWith('submit', expect.any(Function))
 	})
 
+	test('keeps submit disabled when no payment provider is available', () => {
+		new FormHandler('/submit', 'my-org', form, mockTranslations)
+
+		const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]')!
+		expect(submit.disabled).toBe(true)
+	})
+
+	test('keeps submit disabled when amount changes without an available provider', () => {
+		document.body.innerHTML = `
+			<form action="/submit">
+				<input type="hidden" name="amount" value="1000">
+				<div class="donation-amounts">
+					<input name="amount-single" type="number" min="1" value="10">
+				</div>
+				<button type="submit">Submit</button>
+			</form>
+		`
+		form = document.querySelector('form')!
+		new FormHandler('/submit', 'my-org', form, mockTranslations)
+
+		const amount = form.querySelector<HTMLInputElement>('input[type="number"]')!
+		const submit = form.querySelector<HTMLButtonElement>('button[type="submit"]')!
+
+		amount.value = '20'
+		amount.dispatchEvent(new Event('input', { bubbles: true }))
+
+		expect(submit.disabled).toBe(true)
+	})
+
 	test('getSubmitUrl includes the backend host and slug', () => {
 		const handler = new FormHandler(
 			'https://api.lahjoitin.fi',

--- a/src/Blocks/donation-form/view/FormHandler.ts
+++ b/src/Blocks/donation-form/view/FormHandler.ts
@@ -74,6 +74,9 @@ export default class FormHandler {
 		this.#typeRadios = this.#form.querySelectorAll<HTMLInputElement>('input[name="type"]')
 
 		this.#form.addEventListener('submit', this.#onSubmit.bind(this))
+		this.#form.addEventListener('fame-lahjoitukset-amount-validity', () => {
+			this.#allowSubmit(this.#canSubmit())
+		})
 
 		// Bind events to provider radios and type radios.
 		this.#bindProviderEvents()
@@ -93,9 +96,9 @@ export default class FormHandler {
 			})
 		)
 
-		// Form submit requires javascript, so all
+		// Form submit requires JavaScript and an available payment provider, so all
 		// submit buttons are disabled by default.
-		this.#allowSubmit(true)
+		this.#allowSubmit(this.#canSubmit())
 	}
 
 	/**
@@ -109,6 +112,7 @@ export default class FormHandler {
 		this.#providerRadios.forEach(r =>
 			r.addEventListener('change', () => {
 				this.#updateProvider()
+				this.#allowSubmit(this.#canSubmit())
 			})
 		)
 
@@ -117,6 +121,7 @@ export default class FormHandler {
 				this.#filterProvidersByType()
 				this.#updateProvider()
 				this.#updateSubmitLabel()
+				this.#allowSubmit(this.#canSubmit())
 			})
 		)
 	}
@@ -151,6 +156,14 @@ export default class FormHandler {
 			}
 		})
 		this.#updateSubmitLabel()
+	}
+
+	#hasAvailableProvider(): boolean {
+		return !!this.#providerField?.value && this.#providerField.value.trim() !== ''
+	}
+
+	#canSubmit(): boolean {
+		return this.#hasAvailableProvider() && !this.#amount.invalid
 	}
 
 	/**
@@ -232,9 +245,9 @@ export default class FormHandler {
 		this.#updateProvider()
 
 		// Checks provider field value.
-		if (!this.#providerField?.value) {
-			this.addError('provider', 'Select payment method')
+		if (!this.#hasAvailableProvider()) {
 			this.#form.classList.add('was-validated')
+			this.#allowSubmit(false)
 			return
 		}
 
@@ -291,7 +304,7 @@ export default class FormHandler {
 
 			throw error
 		} finally {
-			this.#allowSubmit(true)
+			this.#allowSubmit(this.#canSubmit())
 			this.#form.classList.remove('fame-form--submitting')
 		}
 	}
@@ -353,8 +366,7 @@ export default class FormHandler {
 		// so the browser's constraint validation on the provider inputs can be
 		// overridden when a provider has been selected. Every other field is still
 		// validated normally.
-		const hasValidProvider =
-			!!this.#providerField?.value && this.#providerField?.value.trim() !== ''
+		const hasValidProvider = this.#hasAvailableProvider()
 
 		let valid = true
 

--- a/src/Blocks/donation-providers/render.php
+++ b/src/Blocks/donation-providers/render.php
@@ -52,10 +52,14 @@ foreach ($providers as $p) {
 
 // Filter the saved selection against the providers currently enabled for this
 // organization, so a provider disabled after the block was saved never renders.
-// Fails open: when the API is unreachable ($enabled === null) the saved
-// selection is rendered as-is rather than blanking the donation form.
+// Fails closed: when the API is unreachable or the slug is missing, do not show
+// stale provider choices that may no longer be valid for this organization.
 $enabled = (new Settings())->getEnabledProviders();
-if (is_array($enabled)) {
+$providers_unavailable = !is_array($enabled) || $enabled === [];
+
+if ($providers_unavailable) {
+  $grouped = [];
+} else {
   foreach ($grouped as $type => $list) {
     $filtered = array_values(array_filter($list, static function (array $p) use ($enabled, $type): bool {
       $value = (string) $p['value'];
@@ -68,6 +72,8 @@ if (is_array($enabled)) {
       unset($grouped[$type]);
     }
   }
+
+  $providers_unavailable = $grouped === [];
 }
 
 $isLegendShownForType = static function (string $type) use ($showLegend, $showLegendSingle, $showLegendRecurring): bool {
@@ -84,6 +90,12 @@ $wrapper_attrs = get_block_wrapper_attributes();
 
 ?>
 <div <?php echo $wrapper_attrs; ?>>
+  <?php if ($providers_unavailable) : ?>
+    <div class="fame-form__notice fame-form__notice--warning" role="status">
+      <?php echo esc_html__('Payment methods are currently unavailable. Please try again later.', 'fame_lahjoitukset'); ?>
+    </div>
+  <?php endif; ?>
+
   <?php foreach ($grouped as $type => $list) :
     $single = count($list) === 1;
     $showForType = $isLegendShownForType((string) $type);


### PR DESCRIPTION
- Do not render saved payment provider selections when live provider data is unavailable
- Show a frontend notice when payment methods cannot be resolved
- Keep the donation submit button disabled until a valid provider is available
- Prevent amount changes from enabling submit when no provider is selected
- Add translations for the unavailable payment methods notice
